### PR TITLE
week 3

### DIFF
--- a/week_3/tests/test_resources.py
+++ b/week_3/tests/test_resources.py
@@ -1,5 +1,9 @@
-from dagster import build_init_resource_context
-from workspaces.resources import S3, Redis, redis_resource, s3_resource
+import pickle
+
+from dagster import build_init_resource_context, build_output_context
+
+from workspaces.challenge.week_3_challenge import PostgresBlobIOManager, postgres_blob_manager
+from workspaces.resources import Postgres, S3, Redis, postgres_resource, redis_resource, s3_resource
 
 
 def test_s3_resource():
@@ -26,3 +30,52 @@ def test_redis_resource():
         )
     )
     assert type(resource) is Redis
+
+
+def test_postgres_resource():
+    resource = postgres_resource(
+        build_init_resource_context(
+            config={
+                'host': 'test',
+                'user': 'test',
+                'password': 'test',
+                'database': 'test'
+            }
+        )
+    )
+    assert type(resource) is Postgres
+
+
+def test_postgres_blob_manager():
+    postgres = postgres_resource(
+        build_init_resource_context(
+            config={
+                'host': 'test',
+                'user': 'test',
+                'password': 'test',
+                'database': 'test'
+            }
+        )
+    )
+    manager = postgres_blob_manager(
+        build_init_resource_context(
+            resources={'database': postgres},
+            config={
+                'blob_table': 'blob',
+                'data_table': 'data'
+            }
+        )
+    )
+    assert type(manager) is PostgresBlobIOManager
+    #
+    # data = [{'column_1': 1, 'column_2': 2, 'column_3': 3}]
+    # manager.handle_output(
+    #     context=build_output_context(step_key='step1', run_id='run1', name='result'),
+    #     obj=data
+    # )
+    #
+    # result = postgres.execute('select * from blob')
+    # assert result.rowcount == 1
+    # first = result.first()
+    # assert first['id'] == 'step1/run1/result'
+    # assert first['blob'] == pickle.dumps(data)

--- a/week_3/workspaces/challenge/week_3_challenge.py
+++ b/week_3/workspaces/challenge/week_3_challenge.py
@@ -1,29 +1,121 @@
-from dagster import In, IOManager, Nothing, Out, String, graph, io_manager, op
-from workspaces.resources import postgres_resource
+import json
+import logging
+import pickle
+import random
+from typing import Any, Dict, List, Union
+
+from dagster import IOManager, In, InitResourceContext, InputContext, OpExecutionContext, Out, \
+    OutputContext, String, \
+    graph, io_manager, op
+from sqlalchemy import column, table
+
+from workspaces.resources import Postgres, postgres_resource
+
+logging.basicConfig()
+logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 
 
 class PostgresIOManager(IOManager):
-    def __init__(self):
-        pass
+    def __init__(self, table_str: str):
+        if "." in table_str:
+            schema, table_name = table_str.split('.')
+        else:
+            schema, table_name = None, table_str
+        self.table = table(table_name,
+                           column('column_1'),
+                           column('column_2'),
+                           column('column_3'),
+                           schema=schema)
 
-    def handle_output(self):
-        pass
+    def handle_output(self, context: OutputContext, values: List[Dict[str, str]]):
+        db = context.resources.database
+        stmt = self.table.insert().values(values)
+        db.execute_query(stmt)
 
-    def load_input(self, context):
-        pass
+    def load_input(self, context: InputContext):
+        db = context.resources.database
+        # warning: anything could have inserted into this table!!! x_X
+        stmt = self.table.select()
+        result = db.execute_query(stmt)
+        return [dict(row) for row in result]
 
 
-@io_manager(required_resource_keys={"postgres"})
+class PostgresBlobIOManager(IOManager):
+    def __init__(self, database: Postgres, blob_table: str, data_table: str):
+        self.database = database
+        self.blob_table = blob_table
+        self.data_table = data_table
+        self.table = table(self.blob_table, column('id'), column('pickle_data'))
+
+    def _create_table(self):
+        sql = f'''CREATE TABLE IF NOT EXISTS "{self.blob_table}"
+        (id varchar primary key, pickle_data bytea)'''
+        self.database.execute_query(sql)
+
+    def _store_result(self, id_str: str, obj: Any) -> None:
+        self._create_table()
+        stmt = self.table.insert().values(id=id_str, pickle_data=pickle.dumps(obj))
+        self.database.execute_query(stmt)
+
+    def _retrieve_result(self, id_str: str) -> Any:
+        stmt = self.table.select().where(column('id') == id_str)
+        result = self.database.execute_query(stmt)
+        if result.rowcount == 1:
+            row = result.first()
+            data = pickle.loads(row['pickle_data'])
+            stmt = self.table.delete().where(column('id') == id_str)
+            self.database.execute_query(stmt)
+            return data
+
+    def _store_data(self, table_arg: str, data: List[Dict[str, Any]]) -> None:
+        if len(data) == 0:
+            return None
+        columns = [column(key) for key in data[0].keys()]
+        if "." in table_arg:
+            schema, table_name = table_arg.split('.')
+        else:
+            schema, table_name = None, table_arg
+        stmt = table(table_name, *columns, schema=schema).insert().values(data)
+        self.database.execute_query(stmt)
+
+    def _id_str(self, context: Union[InputContext, OutputContext]) -> str:
+        if context.has_asset_key:
+            ids = context.get_asset_identifier()
+        else:
+            ids = context.get_identifier()
+        return '/'.join(ids)
+
+    def handle_output(self, context: OutputContext, obj: List[Dict[str, str]]) -> None:
+        self._store_result(self._id_str(context), obj)
+        self._store_data(self.data_table, obj)
+
+    def load_input(self, context: InputContext) -> Any:
+        return self._retrieve_result(self._id_str(context))
+
+
+@io_manager(required_resource_keys={"database"})
+def postgres_blob_manager(init_context: InitResourceContext):
+    db = init_context.resources.database
+    blob_table = init_context.resource_config['blob_table']
+    data_table = init_context.resource_config['data_table']
+    return PostgresBlobIOManager(database=db,
+                                 blob_table=blob_table,
+                                 data_table=data_table)
+
+
+@io_manager(required_resource_keys={"database"})
 def postgres_io_manager(init_context):
-    return PostgresIOManager()
+    table_name = init_context.resource_config['table_name']
+    return PostgresIOManager(table_str=table_name)
 
 
 @op(
     config_schema={"table_name": String},
     required_resource_keys={"database"},
+    out=Out(String),
     tags={"kind": "postgres"},
 )
-def create_table(context) -> String:
+def create_table(context: OpExecutionContext) -> String:
     table_name = context.op_config["table_name"]
     schema_name = table_name.split(".")[0]
     sql = f"CREATE SCHEMA IF NOT EXISTS {schema_name};"
@@ -33,19 +125,36 @@ def create_table(context) -> String:
     return table_name
 
 
-@op
-def insert_data():
-    pass
+@op(
+    ins={'table_name': In(String)},
+    out=Out(List[Dict[str, str]], io_manager_key='postgres_io'),
+)
+def insert_data(context: OpExecutionContext, table_name: str) -> List[Dict[str, str]]:
+    result = []
+    for _ in range(10):
+        row = dict()
+        for col in range(3):
+            row[f'column_{col + 1}'] = str(random.random())
+        result.append(row)
+    context.add_output_metadata({'table': table_name})
+    return result
 
 
-@op
-def table_count():
-    pass
+@op(required_resource_keys={'database'},
+    ins={'data': In(input_manager_key='postgres_io')})
+def table_count(context: OpExecutionContext, data):
+    context.log.info(json.dumps(data))
+    context.log.info(len(data))
+    db_count = context.resources.database.execute_query('select count(*) from analytics.table')
+    context.log.info(db_count.scalar())
+    return len(data)
 
 
 @graph
 def week_3_challenge():
-    pass
+    table = create_table()
+    data = insert_data(table)
+    count = table_count(data)
 
 
 docker = {
@@ -58,9 +167,25 @@ docker = {
                 "database": "postgres_db",
             }
         },
+        'postgres_io': {
+            'config': {
+                'table_name': 'analytics.table'
+            }
+        },
+        'postgres_blob': {
+            'config': {
+                'blob_table': 'pgio_blob',
+                'data_table': 'analytics.table'
+            }
+        }
     },
     "ops": {"create_table": {"config": {"table_name": "analytics.table"}}},
 }
 
-
-week_3_challenge_docker = week_3_challenge.to_job()
+week_3_challenge_docker = week_3_challenge.to_job(
+    name='week_3_challenge_docker',
+    config=docker,
+    resource_defs={'database': postgres_resource,
+                   'postgres_io': postgres_io_manager,
+                   'postgres_blob': postgres_blob_manager},
+)

--- a/week_3/workspaces/project/week_3.py
+++ b/week_3/workspaces/project/week_3.py
@@ -3,57 +3,77 @@ from typing import List
 from dagster import (
     In,
     Nothing,
-    Out,
+    OpExecutionContext, Out,
     ResourceDefinition,
     RetryPolicy,
     RunRequest,
     ScheduleDefinition,
-    SkipReason,
+    SensorEvaluationContext, SkipReason,
     graph,
     op,
     schedule,
     sensor,
     static_partitioned_config,
 )
+
 from workspaces.project.sensors import get_s3_keys
 from workspaces.resources import mock_s3_resource, redis_resource, s3_resource
 from workspaces.types import Aggregation, Stock
 
 
-@op
-def get_s3_data():
-    # You can reuse the logic from the previous week
-    pass
+@op(
+    config_schema={'s3_key': str},
+    required_resource_keys={'s3'},
+    out=Out(List[Stock])
+)
+def get_s3_data(context: OpExecutionContext):
+    key = context.op_config['s3_key']
+    context.log.info(key)
+    for x in context.resources.s3.list_keys():
+        context.log.info(x)
+    return [Stock.from_list(row) for row in context.resources.s3.get_data(key)]
 
 
-@op
-def process_data():
-    # You can reuse the logic from the previous week
-    pass
+@op(
+    ins={'stocks': In(List[Stock])},
+    out=Out(Aggregation)
+)
+def process_data(context: OpExecutionContext, stocks: List[Stock]) -> Aggregation:
+    max_stock = max(stocks, key=lambda s: s.high)
+    return Aggregation(date=max_stock.date, high=max_stock.high)
 
 
-@op
-def put_redis_data():
-    # You can reuse the logic from the previous week
-    pass
+@op(
+    required_resource_keys={'redis'},
+    ins={'agg': In(Aggregation)},
+    out=Out(Nothing)
+)
+def put_redis_data(context: OpExecutionContext, agg: Aggregation):
+    context.resources.redis.put_data(name=str(agg.date),
+                                     value=str(agg.high))
 
 
-@op
-def put_s3_data():
-    # You can reuse the logic from the previous week
-    pass
+@op(
+    required_resource_keys={'s3'},
+    ins={'agg': In(Aggregation)},
+    out=Out(Nothing)
+)
+def put_s3_data(context, agg: Aggregation):
+    filename = f'aggregation_{agg.date}.json'
+    context.resources.s3.put_data(key_name=filename,
+                                  data=agg)
 
 
 @graph
 def week_3_pipeline():
-    # You can reuse the logic from the previous week
-    pass
+    agg = process_data(get_s3_data())
+    put_redis_data(agg)
+    put_s3_data(agg)
 
 
 local = {
     "ops": {"get_s3_data": {"config": {"s3_key": "prefix/stock_9.csv"}}},
 }
-
 
 docker = {
     "resources": {
@@ -75,28 +95,55 @@ docker = {
     "ops": {"get_s3_data": {"config": {"s3_key": "prefix/stock_9.csv"}}},
 }
 
+PARTS = [str(i) for i in range(1, 11)]
 
-def docker_config():
-    pass
+
+@static_partitioned_config(
+    partition_keys=PARTS
+)
+def docker_config(partition_key: str = None, full_s3_key: str = None):
+    key = full_s3_key if full_s3_key else f'prefix/stock_{partition_key}.csv'
+    config = docker.copy()
+    config['ops']['get_s3_data']['config']['s3_key'] = key
+    return config
 
 
 week_3_pipeline_local = week_3_pipeline.to_job(
     name="week_3_pipeline_local",
+    config=local,
+    resource_defs={'s3': mock_s3_resource,
+                   'redis': ResourceDefinition.mock_resource()}
 )
 
 week_3_pipeline_docker = week_3_pipeline.to_job(
     name="week_3_pipeline_docker",
+    config=docker_config,
+    resource_defs={'s3': s3_resource,
+                   'redis': redis_resource},
+    op_retry_policy=RetryPolicy(max_retries=10, delay=1)
 )
 
+week_3_schedule_local = ScheduleDefinition(job=week_3_pipeline_local,
+                                           cron_schedule="*/15 * * * *")
 
-week_3_schedule_local = None
 
-
-@schedule
+@schedule(
+    cron_schedule="0 * * * *",
+    job=week_3_pipeline_docker
+)
 def week_3_schedule_docker():
-    pass
+    for part in PARTS:
+        yield week_3_pipeline_docker.run_request_for_partition(partition_key=part, run_key=part)
 
 
-@sensor
-def week_3_sensor_docker():
-    pass
+@sensor(
+    job=week_3_pipeline_docker,
+)
+def week_3_sensor_docker(context: SensorEvaluationContext):
+    keys = get_s3_keys(bucket="dagster", prefix="prefix", endpoint_url='http://localstack:4566')
+    if len(keys) == 0:
+        yield SkipReason('No new s3 files found in bucket.')
+    else:
+        for key in keys:
+            yield RunRequest(run_key=key,
+                             run_config=docker_config(full_s3_key=key))


### PR DESCRIPTION
I made 2 IO managers

PostgresIOManager
* must be configured with a `table_name`
* handle_output - can only write data that matches the schema of the configured table
* load_input - reads all data from the configured table. **WARNING**: this may produce unexpected results, since Ops which use this IOManager to load input will read from the table, rather than the actual values from the upstream output.

PostgresBlobIOManager
* must be configured with a `blob_table` to store arbitrary python pickle bytes. This allow passing data between ops. This for Dagster internal use and should not be queried by any users/analysts.
* must be configured with a `data_table` to store user data.
* handle_output - writes data to `blob_table` for downstream ops, and writes to `data_table` for users. Writing to `data_table` MUST match the schema.
* load_input - loads data from `blob_table` for Ops needing input
